### PR TITLE
add documentation for generate_password & update function 

### DIFF
--- a/docs/example.ipynb
+++ b/docs/example.ipynb
@@ -19,8 +19,15 @@
             ]
         },
         {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Password Strength"
+            ]
+        },
+        {
             "cell_type": "code",
-            "execution_count": 6,
+            "execution_count": null,
             "metadata": {},
             "outputs": [
                 {
@@ -97,11 +104,112 @@
             ]
         },
         {
-            "cell_type": "code",
-            "execution_count": null,
+            "cell_type": "markdown",
             "metadata": {},
-            "outputs": [],
-            "source": []
+            "source": [
+                "### Generate Password\n",
+                "\n",
+                "The `generate_password` function allows users to create a secure, customized password.\n"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### First try: default settings\n",
+                "\n",
+                "Bob creates a password with the default settings. This returns a password of length 12, with at least one uppercase letter, number and symbol. "
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "'`iw:XP-t<32J'"
+                        ]
+                    },
+                    "execution_count": 7,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "from passwordler.generate_password import generate_password\n",
+                "\n",
+                "generate_password()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### Going for Length"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Intrigued, Bob decides to generate a much longer password, setting the `length` to 100 characters. The minimum accepted length is 12 characters."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "'@iWD9x4j^_UM7}Qd46NV[@-dz^qD/i^qSnzP\"yg#eOLy7\\'|emw/Y>ZCDt3GiDi\\'.M7$2zxv&r\\'m>GO_EZ&dlY?OMw9JvjL`4%E>>'"
+                        ]
+                    },
+                    "execution_count": 10,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "generate_password(length=100)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#### Simplifying It"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Next, he experiments with the `include_symbols` and `include_numbers` arguments. He sets both to false, overriding the default settings. This gives him a password with only letters: removing symbols and numbers"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 14,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "'cHaJeZNKwGrh'"
+                        ]
+                    },
+                    "execution_count": 14,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "generate_password(include_symbols=False, include_numbers=False)"
+            ]
         }
     ],
     "metadata": {

--- a/src/passwordler/generate_password.py
+++ b/src/passwordler/generate_password.py
@@ -49,5 +49,4 @@ def generate_password(length=12, include_symbols=True, include_numbers=True):
     random.shuffle(password_characters)
 
     final_password = ''.join(password_characters)
-    print(f'Your password is: {final_password}')
     return final_password


### PR DESCRIPTION
I have continued with our narrative in the example.ipynb file, adding documentation for the generate_password function. I also changed my original function slightly by removing a print statement that was redundant as it already returns the password.